### PR TITLE
Fix for tax line item

### DIFF
--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -75,6 +75,7 @@ def setting_tax_defaults(doc):
             
             if item_tax_template.sales_taxes_and_charges_template:
                 doc.taxes_and_charges = item_tax_template.sales_taxes_and_charges_template
+                doc.taxes = []
 
             doc.run_method("set_missing_values")
             doc.run_method("calculate_taxes_and_totals")


### PR DESCRIPTION
when code changes from "Products" to "Services" and back on a transaction like Quotation then the tax line items where not refreshed correctly.

![switching_tax_item_group](https://github.com/imat-open-source/German-Accounting/assets/22279621/3215177c-ae1f-49ed-a308-22873eb91ea4)
