### PR TITLE
create custom field `debtor_creditor_number`

### DIFF
--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -115,10 +115,21 @@ def get_custom_fields():
 		}	
 	]
 
+	custom_fields_party_account = [
+		{
+			"label": "Debtor/Creditor Number",
+			"fieldname": "debtor_creditor_number",
+			"fieldtype": "Data",
+			"insert_after": "account",
+			"translatable": 0,
+		},
+	]
+
 	return {
 		"Quotation": custom_fields_quotation,
 		"Sales Order": custom_fields_so_si,
 		"Item Group": custom_fields_item_group,
 		"Sales Invoice": custom_fields_so_si,
-		"Country": custom_fields_country
+		"Country": custom_fields_country,
+		"Party Account": custom_fields_party_account,
 	}


### PR DESCRIPTION
The custom field has been moved from ERPNext 13 to a new app "ERPNext DATEV" (since version 14), so we need to handle it.

We have no reason to use the entire app as we only need one custom field from it. 

Field definition (reference) for ERPNext14:
https://github.com/alyf-de/erpnext_datev/blob/version-14/erpnext_datev/install.py